### PR TITLE
Fix CI: use db:migrate instead of db:test:prepare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           bundler-cache: true
       - name: Prepare database
-        run: bundle exec rails db:test:prepare
+        run: bundle exec rails db:migrate
       - name: Run RSpec
         run: bundle exec rspec
 


### PR DESCRIPTION
## Context
CI fails on the "Prepare database" step because `db:test:prepare` requires `db/schema.rb` to exist. Since this is a template repo, `schema.rb` shouldn't be committed — it should be generated from migrations.

## What Changed
- Changed CI database preparation from `db:test:prepare` to `db:migrate` in `.github/workflows/ci.yml`

## How to Test
- CI should pass on this PR (the test job should no longer fail at the database step)
- Verify RSpec runs successfully after migration

## Deployment Tasks
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)