### PR TITLE
Add harness-engineering knowledge base docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Read `docs/repo_map.md` first — it maps every directory and file to its purpos
 - `docs/architecture.md` — System overview and request flow
 - `docs/decision_log.md` — Append-only ADR log
 - `docs/components.md` — UI component inventory
+- `docs/ci.md` — CI pipeline checks and how to fix failures
+- `docs/reusable.md` — Inventory of reusable abstractions (check before building new ones)
 
 ## Tech Stack
 
@@ -38,6 +40,8 @@ Read `docs/repo_map.md` first — it maps every directory and file to its purpos
 - **Turbo first** — use Turbo Frames/Streams instead of custom JS
 - **Stimulus** — small, focused controllers for JS interactions
 - **Request specs** preferred over system specs
+- **Extract, don't clone** — When building a feature parallel to an existing one, extract shared behavior into concerns or base classes. Never copy-paste an entire model/service/view.
+- **Check `docs/reusable.md` first** — Before writing a new service or concern, check for existing abstractions that can be reused or extended.
 
 ## Code Quality
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,75 @@
+# CI Pipeline
+
+Run `bin/ci` locally before pushing. It runs the same checks as `.github/workflows/ci.yml` (except `importmap audit`, which only runs in GitHub Actions).
+
+## Jobs
+
+| Job | Tool | What It Checks |
+|---|---|---|
+| **Lint** | RuboCop | Code style, method/class size, complexity |
+| **Security** | Brakeman + bundle-audit + importmap audit | Vulnerabilities in code and dependencies |
+| **Test** | RSpec | Unit, request, and model specs |
+| **E2E** | Playwright (Station C) | End-to-end browser tests |
+
+## Fixing Failures
+
+### RuboCop
+
+**What it enforces:** Method length (max 10), class length (max 100), cyclomatic complexity (max 7), perceived complexity (max 8), ABC size (max 17), plus Standard/Shopify style rules.
+
+**Common failures:**
+- **Method too long** — Extract a private method. If the method does two things, it should be two methods.
+- **Class too long** — Extract a concern (`app/models/concerns/`) or a service object (`app/services/`).
+- **ABC/complexity too high** — Reduce branching. Replace conditionals with guard clauses or polymorphism.
+- **Style violations** — Run `bundle exec rubocop -a` to auto-fix safe cops. Review changes before committing.
+
+**Config:** `.rubocop.yml`
+
+### RubyCritic
+
+Runs locally via `bundle exec rubycritic`. Enforced when configured in CI. Minimum score: 85.
+
+RubyCritic scores are driven by three tools:
+1. **Flay** (duplication) — Detects structural similarity between code blocks. **This is the #1 score killer.** Two parallel features with copy-pasted models, services, or views will tank the score. Fix: extract shared behavior into concerns, base classes, or shared partials.
+2. **Flog** (complexity) — Penalizes deeply nested conditionals, long methods, and ABC complexity. Fix: same as RuboCop complexity fixes.
+3. **Reek** (code smells) — Catches feature envy, long parameter lists, data clumps, duplicate method calls. Fix: extract method, introduce parameter object, or move logic to the right class.
+
+**Key insight:** If you're building a feature parallel to an existing one, **extract shared abstractions first** (concern, base service, shared partial). Cloning an entire model/service/view and modifying it creates duplication that Flay will catch, dragging the score below 85.
+
+**Config:** `.rubycritic.yml` — paths, minimum_score, threshold_score.
+
+### Brakeman
+
+**What it catches:** SQL injection, XSS, mass assignment, command injection, file access, and other OWASP vulnerabilities. Runs with `-w3` (high-confidence warnings only).
+
+**Common warnings:**
+- **SQL injection** — Use parameterized queries or ActiveRecord methods, never string interpolation in `.where()`.
+- **Mass assignment** — Use strong parameters (`params.expect()` per Telos convention). Never pass raw params to `.create` or `.update`.
+- **Cross-site scripting** — Don't use `raw` or `html_safe` on user input. ERB auto-escapes by default — trust it.
+- **Dynamic render path** — Don't pass user input to `render`. Use a whitelist of allowed templates.
+- **File access** — Don't build file paths from user input. Use `ActiveStorage` for uploads.
+
+**False positives:** If Brakeman flags something safe, add an ignore entry to `config/brakeman.ignore` with a note explaining why.
+
+### bundle-audit
+
+**What it catches:** Known CVEs in gem dependencies.
+
+**Fix:** `bundle update <gem_name>` to patch the vulnerable gem. If no patch exists, check the advisory for workarounds or pin to a safe version.
+
+### importmap audit
+
+**What it catches:** Known vulnerabilities in JavaScript packages managed by importmap.
+
+**Fix:** Update the pinned version in `config/importmap.rb`.
+
+### RSpec
+
+**Common failures:**
+- **Missing test coverage** — Every public service method and controller action needs a spec.
+- **Factory issues** — Check `spec/factories/` for missing or outdated factory definitions.
+- **Database state** — Use `let` (lazy) and `before` blocks. Avoid `let!` unless ordering matters.
+
+### E2E
+
+**Stub until Station C is implemented.** Will run Playwright browser tests against the running app.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -198,3 +198,60 @@ Three-layer approach:
 1. **Model validations** — data integrity (presence, format, inclusion)
 2. **Custom validators** — complex logic in `app/validators/`
 3. **Service validators** — business rules and external dependencies
+
+## i18n Conventions
+
+- **Shared keys** (navbar, flash messages, errors, common labels) go in the root locale file: `config/locales/{locale}.yml`
+- **Feature-specific keys** go in their own file: `config/locales/{feature}/{locale}.yml`
+- All supported locales must have matching key structures. If you add a key to `en.yml`, add it to `es.yml` too.
+- Use Rails' built-in scoping: `t(".title")` in views resolves based on the template path.
+
+```
+config/locales/
+  en.yml              # shared: navbar, flash, errors, common
+  es.yml
+  devise.en.yml       # devise-specific
+  listings/
+    en.yml            # feature-specific: listings
+    es.yml
+```
+
+## Shared Concerns
+
+When two models share 3+ methods with identical logic, extract a concern to `app/models/concerns/`. Name descriptively: `Chartable`, `Sluggable`, `Trackable`.
+
+```ruby
+# app/models/concerns/sluggable.rb
+module Sluggable
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :generate_slug
+  end
+
+  private
+
+  def generate_slug
+    self.slug = name&.parameterize
+  end
+end
+```
+
+Same rule applies to controllers: shared behavior goes in `app/controllers/concerns/`.
+
+## Shared View Partials
+
+When two features share HTML structure, extract to `app/views/shared/`. Partials **must** use local variables only — never instance variables.
+
+```erb
+<%# app/views/shared/_card.html.erb %>
+<div class="rounded-lg border p-4">
+  <h3><%= title %></h3>
+  <%= yield %>
+</div>
+
+<%# Usage %>
+<%= render "shared/card", title: "Details" do %>
+  <p>Card content here</p>
+<% end %>
+```

--- a/docs/repo_map.md
+++ b/docs/repo_map.md
@@ -7,7 +7,9 @@ Where things live and what they do.
 | Directory | Purpose |
 |---|---|
 | `app/controllers/` | Thin controllers — instantiate services, handle responses |
+| `app/controllers/concerns/` | Shared controller behavior (authentication, locale, etc.) |
 | `app/models/` | Persistence, associations, validations, scopes |
+| `app/models/concerns/` | Shared model behavior (extracted when 3+ methods are duplicated) |
 | `app/services/` | Business logic — service objects with `call` or `save` |
 | `app/policies/` | ActionPolicy authorization policies |
 | `app/validators/` | Custom validator classes for complex validation logic |
@@ -15,6 +17,8 @@ Where things live and what they do.
 | `app/javascript/controllers/` | Stimulus controllers |
 | `app/jobs/` | Background jobs — thin wrappers that delegate to services |
 | `config/` | Rails configuration, routes, initializers |
+| `config/locales/` | Shared i18n keys (navbar, flash, errors) |
+| `config/locales/{feature}/` | Feature-specific i18n keys |
 | `db/` | Migrations and schema (SQLite3) |
 | `spec/` | RSpec tests — request specs, model specs, service specs |
 | `docs/` | Project documentation (patterns, architecture, decisions) |
@@ -27,8 +31,10 @@ Where things live and what they do.
 | `CLAUDE.md` | Agent entry point — tech stack, key rules, quick start |
 | `Procfile.dev` | Process definitions for `bin/dev` |
 | `.rubocop.yml` | Linting rules (Standard + Rails extensions) |
-| `.rubycritic.yml` | Code quality thresholds |
+| `.rubycritic.yml` | Code quality thresholds (minimum score, paths) |
 | `.rspec` | RSpec configuration |
+| `docs/ci.md` | CI pipeline checks and remediation playbook |
+| `docs/reusable.md` | Inventory of reusable abstractions |
 | `config/routes.rb` | All application routes |
 | `db/schema.rb` | Current database schema (auto-generated) |
 

--- a/docs/reusable.md
+++ b/docs/reusable.md
@@ -1,0 +1,30 @@
+# Reusable Abstractions
+
+**Before building a new service, concern, or policy, check this file.** Existing abstractions should be reused or extended, not duplicated.
+
+**When you add a new reusable abstraction, add it here.**
+
+## Services
+
+| Name | Location | What It Does | When to Use |
+|---|---|---|---|
+| `ApplicationService` | `app/services/application_service.rb` | Base class with `call`/`save` class methods that delegate to instance methods. Defines `Error` base exception. | Inherit from this for all service objects. Use `call` for operations that return data, `save` for operations that persist. |
+
+## Policies
+
+| Name | Location | What It Does | When to Use |
+|---|---|---|---|
+| `ApplicationPolicy` | `app/policies/application_policy.rb` | Base policy with default-deny for all actions. Provides `owner?` helper. | Inherit from this for all authorization policies. Override action methods (`create?`, `update?`, etc.) to allow access. |
+
+## Controller Concerns
+
+| Name | Location | What It Does | When to Use |
+|---|---|---|---|
+| `Authenticatable` | `app/controllers/concerns/authenticatable.rb` | Adds `before_action :authenticate_user!` and configures Devise redirect paths. | Include in controllers that require authentication. Already included in `ApplicationController`. |
+| `LocaleSettable` | `app/controllers/concerns/locale_settable.rb` | Sets `I18n.locale` from params or session using `around_action`. | Include in controllers that need locale switching. |
+
+## Model Concerns
+
+_None yet. Add shared model behavior here as the application grows._
+
+When two models share 3+ methods with identical logic, extract a concern here. Name descriptively: `Chartable`, `Sluggable`, `Trackable`.


### PR DESCRIPTION
## Summary

- Adds `docs/ci.md` — CI pipeline remediation playbook mapping every check to fix instructions, with detailed RubyCritic section explaining Flay/Flog/Reek scoring
- Adds `docs/reusable.md` — inventory of existing abstractions (ApplicationService, ApplicationPolicy, Authenticatable, LocaleSettable) so agents check before building new ones
- Adds "extract, don't clone" and "check reusable.md first" golden rules to `CLAUDE.md`
- Adds i18n, shared concerns, and shared view partials conventions to `docs/patterns.md`
- Adds locale dirs, concern dirs, and new doc files to `docs/repo_map.md`

## Context

Experiment 1 of the CI research plan compared two identical feature implementations — one with a knowledge base, one without. Both failed CI on first attempt (RubyCritic) and both made the same architectural mistake (cloning instead of extracting shared abstractions). These docs address the specific gaps the experiment revealed.

## How to Test

- Read each doc file and verify cross-references point to files that exist in the repo
- Confirm `CLAUDE.md` stays concise (59 lines)
- Confirm `docs/ci.md` job table matches `.github/workflows/ci.yml` and `bin/ci`

## Deployment Tasks

None — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)