### PR TITLE
Add devcontainer for safe Claude Code sandbox

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM ruby:4.0.0
 
 ARG TZ
 ENV TZ="$TZ"
+ARG CLAUDE_INSTALLER_URL="https://claude.ai/install.sh"
+ARG CLAUDE_INSTALLER_SHA256="431889ac7d056f636aaf5b71524666d04c89c45560f80329940846479d484778"
 
 # Install basic development tools, iptables/ipset, and Rails dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -9,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   git \
   procps \
   sudo \
+  locales \
   fzf \
   zsh \
   man-db \
@@ -28,6 +31,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libvips-dev \
   curl \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+  locale-gen && \
+  update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 # Create non-root user
 ARG USERNAME=developer
@@ -64,6 +71,8 @@ USER $USERNAME
 ENV SHELL=/bin/zsh
 ENV EDITOR=nano
 ENV VISUAL=nano
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 ENV PATH="/home/developer/.local/bin:$PATH"
 
 # Install zsh with plugins
@@ -77,7 +86,10 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude Code via native installer
-RUN curl -fsSL https://claude.ai/install.sh | bash
+RUN curl -fsSL "$CLAUDE_INSTALLER_URL" -o /tmp/claude-install.sh && \
+  echo "$CLAUDE_INSTALLER_SHA256  /tmp/claude-install.sh" | sha256sum -c - && \
+  bash /tmp/claude-install.sh && \
+  rm /tmp/claude-install.sh
 
 # Copy and set up firewall script
 COPY init-firewall.sh /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
     "args": {
       "TZ": "${localEnv:TZ:America/Los_Angeles}",
       "GIT_DELTA_VERSION": "0.18.2",
-      "ZSH_IN_DOCKER_VERSION": "1.2.0"
+      "ZSH_IN_DOCKER_VERSION": "1.2.0",
+      "CLAUDE_INSTALLER_SHA256": "431889ac7d056f636aaf5b71524666d04c89c45560f80329940846479d484778"
     }
   },
   "runArgs": [

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -3,14 +3,16 @@ set -euo pipefail
 
 echo "==> Initializing firewall rules..."
 
-# ---------- helpers ---------------------------------------------------------
+# ---------- helpers ----------------------------------------------------------
 
-validate_cidr() {
-  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]
+ipset_add_safe() {
+  local set_name="$1"
+  local value="$2"
+  ipset add "$set_name" "$value" 2>/dev/null || true
 }
 
-validate_ip() {
-  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]
+is_ipv6_enabled() {
+  [ -f /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" = "0" ]
 }
 
 # ---------- preserve Docker DNS ---------------------------------------------
@@ -28,7 +30,15 @@ iptables -t nat -F
 iptables -t nat -X 2>/dev/null || true
 iptables -t mangle -F
 iptables -t mangle -X 2>/dev/null || true
-ipset destroy allowed-domains 2>/dev/null || true
+ipset destroy allowed-domains-v4 2>/dev/null || true
+ipset destroy allowed-domains-v6 2>/dev/null || true
+
+if command -v ip6tables >/dev/null 2>&1; then
+  ip6tables -F 2>/dev/null || true
+  ip6tables -X 2>/dev/null || true
+  ip6tables -t mangle -F 2>/dev/null || true
+  ip6tables -t mangle -X 2>/dev/null || true
+fi
 
 # Restore Docker DNS rules
 if [ -n "$DOCKER_DNS_RULES" ]; then
@@ -39,7 +49,8 @@ fi
 
 # ---------- create ipset for allowed domains --------------------------------
 
-ipset create allowed-domains hash:net
+ipset create allowed-domains-v4 hash:net family inet
+ipset create allowed-domains-v6 hash:net family inet6
 
 # ---------- GitHub IP ranges ------------------------------------------------
 
@@ -51,15 +62,17 @@ if [ -n "$GITHUB_META" ]; then
     [.hooks, .web, .api, .git, .packages, .pages, .actions, .dependabot, .copilot]
     | map(select(. != null))
     | flatten
-    | map(select(test("^[0-9]")))
+    | map(select(type == "string"))
     | unique
     | .[]' 2>/dev/null || echo "")
 
   if [ -n "$GITHUB_CIDRS" ]; then
     AGGREGATED=$(echo "$GITHUB_CIDRS" | aggregate -q 2>/dev/null || echo "$GITHUB_CIDRS")
     while IFS= read -r cidr; do
-      if validate_cidr "$cidr"; then
-        ipset add allowed-domains "$cidr" 2>/dev/null || true
+      if [[ "$cidr" == *:* ]]; then
+        ipset_add_safe allowed-domains-v6 "$cidr"
+      else
+        ipset_add_safe allowed-domains-v4 "$cidr"
       fi
     done <<< "$AGGREGATED"
     echo "    GitHub IP ranges added."
@@ -84,6 +97,11 @@ ALLOWED_DOMAINS=(
   "index.rubygems.org"
   "rubygems.pkg.github.com"
 
+  # GitHub
+  "github.com"
+  "api.github.com"
+  "codeload.github.com"
+
   # VS Code / devcontainer connectivity
   "marketplace.visualstudio.com"
   "vscode.blob.core.windows.net"
@@ -92,25 +110,17 @@ ALLOWED_DOMAINS=(
 
 echo "==> Resolving allowed domains..."
 for domain in "${ALLOWED_DOMAINS[@]}"; do
-  ips=$(dig +short A "$domain" 2>/dev/null | grep -E '^[0-9]+\.' || true)
-  for ip in $ips; do
-    if validate_ip "$ip"; then
-      ipset add allowed-domains "$ip/32" 2>/dev/null || true
-    fi
+  ipv4_ips=$(dig +short A "$domain" 2>/dev/null || true)
+  for ip in $ipv4_ips; do
+    ipset_add_safe allowed-domains-v4 "$ip/32"
+  done
+
+  ipv6_ips=$(dig +short AAAA "$domain" 2>/dev/null || true)
+  for ip in $ipv6_ips; do
+    ipset_add_safe allowed-domains-v6 "$ip/128"
   done
 done
 echo "    Domain IPs resolved and added."
-
-# ---------- detect host network ---------------------------------------------
-
-HOST_NET=$(ip route | grep default | awk '{print $3}' | head -1)
-HOST_SUBNET=""
-if [ -n "$HOST_NET" ]; then
-  HOST_SUBNET=$(ip route | grep -v default \
-    | grep "$(ip route | grep default | awk '{print $5}' | head -1)" \
-    | awk '{print $1}' | head -1)
-  echo "    Host subnet detected as: ${HOST_SUBNET:-unknown}"
-fi
 
 # ---------- apply firewall rules -------------------------------------------
 
@@ -131,27 +141,38 @@ iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A OUTPUT -p udp --dport 53 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
 
-# Allow SSH
-iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
-
-# Allow host network (for Docker host services, database, etc.)
-if [ -n "$HOST_SUBNET" ]; then
-  iptables -A OUTPUT -d "$HOST_SUBNET" -j ACCEPT
-  iptables -A INPUT -s "$HOST_SUBNET" -j ACCEPT
-fi
-
 # Allow HTTPS outbound to allowed destinations only
-iptables -A OUTPUT -p tcp --dport 443 -m set --match-set allowed-domains dst -j ACCEPT
+iptables -A OUTPUT -p tcp --dport 443 -m set --match-set allowed-domains-v4 dst -j ACCEPT
 
 # Reject everything else
 iptables -A OUTPUT -j REJECT --reject-with icmp-admin-prohibited
+
+# IPv6 rules mirror IPv4 rules to avoid egress bypasses
+if command -v ip6tables >/dev/null 2>&1 && is_ipv6_enabled; then
+  ip6tables -P INPUT DROP
+  ip6tables -P FORWARD DROP
+  ip6tables -P OUTPUT DROP
+
+  ip6tables -A INPUT -i lo -j ACCEPT
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+
+  ip6tables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+
+  ip6tables -A OUTPUT -p udp --dport 53 -j ACCEPT
+  ip6tables -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+  ip6tables -A OUTPUT -p tcp --dport 443 -m set --match-set allowed-domains-v6 dst -j ACCEPT
+  ip6tables -A OUTPUT -j REJECT --reject-with icmp6-adm-prohibited
+fi
 
 # ---------- verification ----------------------------------------------------
 
 echo "==> Verifying firewall..."
 
 if curl -sf --connect-timeout 3 https://example.com > /dev/null 2>&1; then
-  echo "    WARNING: example.com is reachable (firewall may not be working)"
+  echo "    ERROR: example.com is reachable; firewall is not enforcing default deny"
+  exit 1
 else
   echo "    OK: example.com is blocked"
 fi
@@ -159,7 +180,8 @@ fi
 if curl -sf --connect-timeout 5 https://api.github.com > /dev/null 2>&1; then
   echo "    OK: api.github.com is reachable"
 else
-  echo "    WARNING: api.github.com is not reachable"
+  echo "    ERROR: api.github.com is not reachable; allowlist is incomplete"
+  exit 1
 fi
 
 echo "==> Firewall initialized."


### PR DESCRIPTION
## Context

Enables developers to run `claude --dangerously-skip-permissions` safely by providing an isolated container with network-level restrictions. Based on the [official Claude Code reference devcontainer](https://github.com/anthropics/claude-code/tree/main/.devcontainer), adapted for this Rails stack.

## What Changed

Three new files in `.devcontainer/`:

- **Dockerfile** — Ruby 4.0.0 base image with Rails dependencies (sqlite3, libvips, libyaml), Claude Code native installer, zsh with Oh-My-Zsh, git-delta, and firewall tooling. Runs as non-root `developer` user.
- **devcontainer.json** — VS Code integration (Ruby LSP, GitLens, Claude Code extensions), persistent volumes for auth and shell history, lifecycle hooks for `bundle install` and firewall initialization.
- **init-firewall.sh** — Default-deny iptables firewall that only allows outbound to: Claude API, GitHub, RubyGems, VS Code marketplace, and Sentry/Statsig (telemetry). Self-verifies on startup by confirming `example.com` is blocked and `api.github.com` is reachable.

Key technical decisions:
- Native installer instead of deprecated npm package (no Node.js dependency needed)
- Fixed Docker volume names (not tied to `devcontainerId`) so auth persists across container rebuilds
- `storage.googleapis.com` and `claude.ai` added to firewall allowlist for native installer auto-updates

## How to Test

1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code
2. Open the repo and click "Reopen in Container" (or use `devcontainer up --workspace-folder .` from CLI)
3. Wait for build + `bundle install` + firewall init
4. Inside the container, verify:
   - `claude --version` returns a version
   - `curl --connect-timeout 5 https://example.com` fails (blocked)
   - `curl --connect-timeout 5 https://api.github.com/zen` succeeds (allowed)
   - `claude --dangerously-skip-permissions` starts successfully
5. Destroy and recreate the container — verify auth persists without re-login

## Deployment Tasks

None


🤖 Generated with [Claude Code](https://claude.com/claude-code)